### PR TITLE
data/bootstrap: Add -E option for functions to inherit trap

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euoE pipefail ## -E option will cause functions to inherit trap
 
 . /usr/local/bin/release-image.sh
 


### PR DESCRIPTION
The trap command to delete etcd-signer on failure isn't getting invoked as functions don't inherit trap commands without -E option.